### PR TITLE
Fix geo coordinates, meta description, and noscript FAQ coverage

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5" />
     <title>Poorvam Care - Best Child Therapy & Hearing Center in Electronic City, Bangalore</title>
-    <meta name="description" content="Poorvam Care offers early intervention therapy for children with ASD, speech delay, and developmental challenges. Led by Apoorva Rai, MASLP, 13+ years experience. Electronic City, Bangalore." />
+    <meta name="description" content="Poorvam Care offers speech therapy, occupational therapy, ABA therapy, and special education for children in Electronic City, Bangalore. Led by Apoorva Rai, MASLP, 13+ years experience. Call +91 886 176 4343." />
     <meta name="keywords" content="speech therapy Bangalore, occupational therapy Electronic City, child development center Bangalore, hearing center Electronic City, ABA therapy Bangalore, autism therapy near me, best speech therapist Electronic City, hearing test Bangalore, pediatric therapy Bangalore, Poorvam Care, speech therapy for autism Electronic City, early intervention therapy Bangalore" />
     <meta name="geo.region" content="IN-KA" />
     <meta name="geo.placename" content="Electronic City, Bangalore" />
-    <meta name="geo.position" content="12.8311;77.6483" />
-    <meta name="ICBM" content="12.8311, 77.6483" />
+    <meta name="geo.position" content="12.8456;77.6603" />
+    <meta name="ICBM" content="12.8456, 77.6603" />
     <link rel="canonical" href="https://poorvamcare.in/" />
 
     <!-- Open Graph -->
@@ -69,9 +69,10 @@
       ],
       "geo": {
         "@type": "GeoCoordinates",
-        "latitude": "12.8311",
-        "longitude": "77.6483"
+        "latitude": "12.8456",
+        "longitude": "77.6603"
       },
+      "hasMap": "https://maps.google.com/?q=Poorvam+Care+Electronic+City+Bangalore",
       "openingHours": "Mo-Sa 09:00-18:00",
       "openingHoursSpecification": [
         {
@@ -194,6 +195,21 @@
 
         <h3>What is the cost of speech therapy in Bangalore?</h3>
         <p>Session fees vary based on the type of therapy and frequency. We offer flexible packages to suit different family budgets. Contact us for a free initial consultation where we can discuss your child's needs and recommend an appropriate therapy plan with transparent pricing.</p>
+
+        <h3>How many sessions does a child typically need?</h3>
+        <p>The number of sessions depends on the child's condition, severity, and therapy goals. Most children attend 2-3 sessions per week. Some see noticeable improvement within 3-6 months, while others benefit from longer-term support. We conduct regular assessments and adjust the therapy plan as your child progresses.</p>
+
+        <h3>What is the difference between speech therapy and occupational therapy?</h3>
+        <p>Speech therapy focuses on communication skills — helping children speak clearly, understand language, and express themselves. Occupational therapy addresses fine motor skills, sensory processing, coordination, and daily living activities. Many children benefit from both therapies working together, which is why Poorvam Care offers integrated multi-disciplinary care under one roof.</p>
+
+        <h3>Do you work with children who have a cochlear implant?</h3>
+        <p>Yes, we provide specialised cochlear implant rehabilitation including auditory verbal therapy (AVT) and speech-language therapy for children with cochlear implants. Our hearing centre offers comprehensive support from pre-implant assessment through post-implant therapy, helping children develop listening and spoken language skills.</p>
+
+        <h3>How do I book an appointment at Poorvam Care?</h3>
+        <p>You can book a free consultation by calling us at +91 886 176 4343, sending a WhatsApp message to the same number, filling out our online contact form, or visiting our centres in Electronic City Phase 1 or Phase 2, Bangalore. We typically respond within 24 hours.</p>
+
+        <h3>Do you offer online therapy or home visits?</h3>
+        <p>Yes, we offer teletherapy options for speech therapy, behavioural consultations, and parent training sessions. Online therapy is ideal for follow-up sessions and for working parents who need flexibility. In-person sessions are available at our Electronic City locations in Bangalore.</p>
 
         <p><a href="https://poorvamcare.in">Visit Poorvam Care</a> — Trusted by 2500+ families in Bangalore.</p>
       </div>

--- a/client/src/components/seo-head.tsx
+++ b/client/src/components/seo-head.tsx
@@ -32,7 +32,7 @@ export default function SeoHead({ title, description, canonical, ogImage, keywor
     // Local SEO geo meta tags
     setMeta("geo.region", "IN-KA");
     setMeta("geo.placename", "Electronic City, Bangalore");
-    setMeta("geo.position", "12.8311;77.6483");
+    setMeta("geo.position", "12.8456;77.6603");
 
     if (canonical) {
       let link = document.querySelector('link[rel="canonical"]') as HTMLLinkElement;

--- a/client/src/components/structured-data.tsx
+++ b/client/src/components/structured-data.tsx
@@ -43,9 +43,10 @@ export const organizationSchema = {
   ],
   "geo": {
     "@type": "GeoCoordinates",
-    "latitude": "12.8311",
-    "longitude": "77.6483"
+    "latitude": "12.8456",
+    "longitude": "77.6603"
   },
+  "hasMap": "https://maps.google.com/?q=Poorvam+Care+Electronic+City+Bangalore",
   "openingHoursSpecification": [
     {
       "@type": "OpeningHoursSpecification",

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -47,7 +47,7 @@ export default function Home() {
     <>
       <SeoHead
         title="Poorvam Care - Best Child Therapy & Hearing Center in Electronic City, Bangalore"
-        description="Poorvam Care offers early intervention therapy for children with ASD, speech delay, and developmental challenges. Led by Apoorva Rai, MASLP. Electronic City, Bangalore."
+        description="Poorvam Care offers speech therapy, occupational therapy, ABA therapy, and special education for children in Electronic City, Bangalore. Led by Apoorva Rai, MASLP, 13+ years experience. Call +91 886 176 4343."
         canonical="https://poorvamcare.in/"
         ogImage="https://poorvamcare.in/og-image.jpg"
         keywords="speech therapy Bangalore, occupational therapy Electronic City, child development center Bangalore, hearing center Electronic City, ABA therapy Bangalore, autism therapy near me, best speech therapist Electronic City, hearing test Bangalore, pediatric therapy Bangalore, Poorvam Care, speech therapy for autism Electronic City, early intervention therapy Bangalore"


### PR DESCRIPTION
- Update geo coordinates from 12.8311/77.6483 to 12.8456/77.6603 in index.html (schema + meta tags), structured-data.tsx, and seo-head.tsx
- Add hasMap property linking to Google Maps in both schema locations
- Update meta description to include phone number (+91 886 176 4343) and list all services (speech therapy, OT, ABA, special education)
- Add 5 missing FAQ entries to noscript fallback in index.html: sessions needed, speech vs OT difference, cochlear implant, booking, and online/home therapy

https://claude.ai/code/session_016vKPGMmfmShBxaTKruGQSE