### PR TITLE
Fix duplicate FAQPage schema causing Google Search Console validation error

### DIFF
--- a/client/src/pages/faq.tsx
+++ b/client/src/pages/faq.tsx
@@ -1,5 +1,5 @@
 import SeoHead from "@/components/seo-head";
-import StructuredData, { createFAQSchema, createBreadcrumbSchema } from "@/components/structured-data";
+import StructuredData, { createBreadcrumbSchema } from "@/components/structured-data";
 import FAQSection from "@/components/faq-section";
 import { Link } from "wouter";
 
@@ -55,7 +55,6 @@ export default function FAQPage() {
         canonical="https://poorvamcare.in/faq"
         keywords="speech therapy FAQ, occupational therapy questions, autism therapy Bangalore, child development questions, speech therapy cost Bangalore, when to start speech therapy"
       />
-      <StructuredData data={createFAQSchema(faqData)} />
       <StructuredData data={createBreadcrumbSchema([
         { name: "Home", url: "https://poorvamcare.in/" },
         { name: "FAQ", url: "https://poorvamcare.in/faq" },


### PR DESCRIPTION
## Summary
- Fix "Duplicate field FAQPage" error flagged by Google Search Console URL Inspection on `/faq`
- Root cause: both `faq.tsx` and the `<FAQSection>` component it renders were each injecting a `FAQPage` JSON-LD schema, resulting in two `FAQPage` schemas on the same page
- Fix: removed the redundant `createFAQSchema` call from `faq.tsx` since `FAQSection` already handles it

## Context
The Lighthouse score from PageSpeed Insights shows **83/100 on mobile** with:
- FCP: 3.0s (needs improvement)
- LCP: 3.5s (needs improvement)
- TBT: 20ms (good)
- CLS: 0.001 (good)

The duplicate schema fix resolves the rich results eligibility issue for FAQ snippets in search results.

## Test plan
- [ ] Re-run Live Test in Google Search Console URL Inspection for `https://poorvamcare.in/faq`
- [ ] Confirm "Duplicate field FAQPage" error is gone
- [ ] Verify FAQ rich results are still detected correctly

https://claude.ai/code/session_016vKPGMmfmShBxaTKruGQSE